### PR TITLE
add docker compose file that includes pulling the ai/gemma3:1B-Q4_K_M model

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  visual-chatbot:
+    image: mikesir87/visual-chatbot
+    ports:
+      - "3000:3000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    tty: true
+    stdin_open: true
+    depends_on:
+      - ai-runner
+
+  ai-runner:
+    provider:
+      type: model
+      options:
+        model: ai/gemma3:1B-Q4_K_M


### PR DESCRIPTION
Now that Docker Desktop 4.41 is released, I've added a docker-compose.yml file that will start the visual-chatbot container and will also pull the ai/gemma3:1B-Q4_K_M model if it's not present.

Feel free to accept this PR if you think it will make it a bit easier on users.
